### PR TITLE
reformat to be responsive, style changes to text color, links and code

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,67 +1,65 @@
 <mat-toolbar color="primary">
-  {{title}}
+  <div class="page-title">Angular Update Guide</div>
 </mat-toolbar>
 <div class="page">
   <div class="wizard">
     <div>
       <mat-card>
-        <mat-card-title class="card-title">Select the options matching your project</mat-card-title>
-        <mat-grid-list cols="5" [rowHeight]="80">
-          <mat-grid-tile>Angular</mat-grid-tile>
-          <mat-grid-tile [colspan]="2">
-            <mat-form-field>
-              <mat-select [(ngModel)]="from" placeholder="from">
-                <mat-option *ngFor="let version of versions" [value]="version">{{version.name}}</mat-option>
-              </mat-select>
-            </mat-form-field>
-          </mat-grid-tile>
-          <mat-grid-tile [colspan]="2">
-            <mat-form-field>
-              <mat-select [(ngModel)]="to" placeholder="to">
-                <mat-option *ngFor="let version of versions" [value]="version">{{version.name}}</mat-option>
-              </mat-select>
-            </mat-form-field>
-          </mat-grid-tile>
+        <h3>
+          Select the options matching your project:
+        </h3>
 
-          <mat-grid-tile>How complex is your app?</mat-grid-tile>
-          <mat-grid-tile [colspan]="2">
-            <mat-form-field>
-              <mat-select [(ngModel)]="level">
-                <mat-option [value]="1">Basic</mat-option>
-                <mat-option [value]="2">Medium</mat-option>
-                <mat-option [value]="3">Advanced</mat-option>
-              </mat-select>
-            </mat-form-field>
-          </mat-grid-tile>
-          <mat-grid-tile [colspan]="2"></mat-grid-tile>
+        <mat-card-content>
+
+          <h4>Angular Version</h4>
+
+          <mat-form-field appearance="outline">
+            <mat-select [(ngModel)]="from" placeholder="from">
+              <mat-option *ngFor="let version of versions" [value]="version">{{version.name}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-select [(ngModel)]="to" placeholder="to">
+              <mat-option *ngFor="let version of versions" [value]="version">{{version.name}}</mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <h4>App Complexity</h4>
+          <ng-container>
+              <mat-button-toggle-group #group="matButtonToggleGroup" value="1" [(ngModel)]="level">
+                <mat-button-toggle value="1">Basic</mat-button-toggle>
+                <mat-button-toggle value="2">Medium</mat-button-toggle>
+                <mat-button-toggle value="3">Advanced</mat-button-toggle>
+              </mat-button-toggle-group>
+            </ng-container>
 
           <ng-container *ngFor="let option of optionList">
-            <mat-grid-tile>{{option.name}}</mat-grid-tile>
-            <mat-grid-tile [colspan]="2"><mat-checkbox [(ngModel)]="options[option.id]">I use {{option.name}}</mat-checkbox></mat-grid-tile>
+            <h4>{{option.name}}</h4>
+            <p>
+              <mat-checkbox [(ngModel)]="options[option.id]">I use {{option.name}}</mat-checkbox>
+            </p>
             <mat-grid-tile [colspan]="2"></mat-grid-tile>
           </ng-container>
 
-          <mat-grid-tile>Package manager</mat-grid-tile>
-          <mat-grid-tile [colspan]="2">
-            <mat-form-field>
-              <mat-select [(ngModel)]="packageManager">
-                <mat-option value="npm install">npm</mat-option>
-                <mat-option value="yarn add">yarn</mat-option>
-              </mat-select>
-            </mat-form-field>
-          </mat-grid-tile>
-          <mat-grid-tile [colspan]="2"></mat-grid-tile>
+          <h4>Package Manager</h4>
+          <ng-container>
+            <mat-button-toggle-group [(ngModel)]="packageManager">
+              <mat-button-toggle value="npm install">npm</mat-button-toggle>
+              <mat-button-toggle value="yarn add">yarn</mat-button-toggle>
+            </mat-button-toggle-group>
+          </ng-container>
 
-          <mat-grid-tile [colspan]="5">
-            <button type="button" (click)="showUpdatePath()" mat-raised-button color="primary">Show me how to update!</button>
-          </mat-grid-tile>
-        </mat-grid-list>
+        </mat-card-content>
+        <mat-card-actions>
+          <button type="button" (click)="showUpdatePath()" mat-raised-button color="primary">Show me how to update!</button>
+        </mat-card-actions>
       </mat-card>
 
       <div *ngIf="from.number >= 700 || to.number >= 700">
         <br/>
-        <strong style="color:darkred">Warning:</strong> Plans for releases after the current major release are not finalized and may change. These recommendations are based on
-        scheduled deprecations.
+        <strong style="color:darkred">Warning:</strong> Plans for releases after the current major release are not finalized and may change. These recommendations
+        are based on scheduled deprecations.
       </div>
       <div *ngIf="from.number > to.number">
         <br/>
@@ -74,9 +72,11 @@
     </div>
   </div>
 
+  <!-- RECOMMENDATIONS SECTION -->
+
   <div class="recommendations" *ngIf="beforeRecommendations.length > 0 || duringRecommendations.length > 0 || afterRecommendations.length > 0">
-    <h1>{{title}}</h1>
-    <h2>Before updating</h2>
+    <h2>{{title}}</h2>
+    <h3>Before Updating</h3>
     <div *ngFor="let r of beforeRecommendations">
       <mat-checkbox></mat-checkbox>
       <div style="margin-left:30px;" [innerHTML]="r.renderedStep"></div>
@@ -85,7 +85,7 @@
       <em>There aren't currently any recommendations for moving between these versions.</em>
     </div>
 
-    <h2>During the update</h2>
+    <h3>During the Update</h3>
     <div *ngFor="let r of duringRecommendations">
       <mat-checkbox></mat-checkbox>
       <div style="margin-left:30px;" [innerHTML]="r.renderedStep"></div>
@@ -93,7 +93,7 @@
     <div *ngIf="duringRecommendations.length <= 0">
       <em>There aren't currently any recommendations for moving between these versions.</em>
     </div>
-    <h2>After the update</h2>
+    <h3>After the Update</h3>
     <div *ngFor="let r of afterRecommendations">
       <mat-checkbox></mat-checkbox>
       <div style="margin-left:30px;" [innerHTML]="r.renderedStep"></div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, } from '@angular/core';
 import * as Showdown from 'showdown';
 import { Step, RECOMMENDATIONS } from './recommendations';
 
@@ -54,7 +54,7 @@ export class AppComponent {
     this.duringRecommendations = [];
     this.afterRecommendations = [];
 
-    this.title = `Angular Update Guide - ${this.from.name} -> ${this.to.name} for ${
+    this.title = `Angular Update Guide | ${this.from.name} -> ${this.to.name} for ${
       this.level < 2 ? 'Basic' : this.level < 3 ? 'Medium' : 'Advanced'
     } Apps`;
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,7 +9,9 @@ import {
   MatInputModule,
   MatListModule,
   MatSelectModule,
-  MatToolbarModule
+  MatToolbarModule,
+  MatProgressBarModule,
+  MatButtonToggleModule
 } from '@angular/material';
 
 @NgModule({
@@ -29,6 +31,8 @@ import {
     MatCardModule,
     MatListModule,
     MatGridListModule,
+    MatProgressBarModule,
+    MatButtonToggleModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,8 +8,25 @@
   font-family: 'Roboto', sans-serif;
 }
 
-h1, h2, h3 {
+h1, h2, h3, h4 {
   padding: 16px 0;
+}
+
+h1, h2, h3, h4, h5, h6, p, li, ul, ol, td, th, table {
+  color: #333333;
+}
+
+p {
+  margin-bottom: 16px;
+  line-height: 1.75;
+}
+
+a {
+  color: #3f51b5;
+}
+
+a:hover {
+  color: #283593;
 }
 
 .page {
@@ -17,10 +34,6 @@ h1, h2, h3 {
   max-width: 750px;
   margin: 0 auto;
   font-size: 16px;
-}
-
-p {
-  margin-bottom: 16px;
 }
 
 .wizard > div {
@@ -32,9 +45,20 @@ p {
 }
 
 code {
+  font-size: 14px;
+  line-height: 1.5;
   padding: 0 6px;
-  background-color: #c0c0c0;
+  background-color: #CFD8DC;
   border-radius: 3px;
   font-family: 'Roboto Mono', monospace;
   display:inline-block;
+}
+
+mat-form-field.mat-form-field-appearance-outline .mat-form-field-wrapper {
+  margin-right: 1em;
+}
+
+mat-toolbar .page-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
## Changes
- Page title has tooltip (intended for smaller devices where title is too long to see)
- Layout now responsive and collapses accordingly
- Made text color a bit softer
- Changed line height of paragraphs to give it more spacing for better legibility
- Gave code snippets more room and made background color a bit lighter for better contrast / readability

## To be continued
- Added progress loader bar for future use if needed
- mat-button-toggle-group might not support the standard ng-model binding and when added, the selected item is not visualized (functionality is still working currently)
- It would be ideal if the toolbar title tooltip only appeared when the title is truncated given the window size
