### PR TITLE
replace history state only once, not per step

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -103,11 +103,10 @@ export class AppComponent {
         } else {
         }
       }
-      
-
-      // Update the URL so users can link to this transition
-      this.location.replaceState(`${this.from.name}:${this.to.name}`);
     }
+
+    // Update the URL so users can link to this transition
+    this.location.replaceState(`${this.from.name}:${this.to.name}`);
 
     // Tell everyone how to upgrade for v6 or earlier
     this.renderPreV6Instructions();


### PR DESCRIPTION
In Safari, replacing the history state is limited to 100 times per 30 seconds. So, replacing
the history state from within a loop of 80 items is likely to fail soon with the error:

```
SecurityError: Attempt to use history.replaceState() more than 100 times per 30.000000 seconds
```