### PR TITLE
fix the highlighted area in japanese docs

### DIFF
--- a/src/app/locales/ja_JP.ts
+++ b/src/app/locales/ja_JP.ts
@@ -180,7 +180,7 @@ const steps: LocalizedSteps = {
   },
   'routerlink queryParams typing': {
     action:
-      'queryParams`, `fragment` や `queryParamsHandling` の `routerLink` の値にアクセスしている場合、`undefined` や `null` も受け付けるように型付けを緩和する必要があるかもしれません。',
+      '`queryParams`, `fragment` や `queryParamsHandling` の `routerLink` の値にアクセスしている場合、`undefined` や `null` も受け付けるように型付けを緩和する必要があるかもしれません。',
   },
   'viewencapsulation native removed': {
     action:


### PR DESCRIPTION
Fix the highlighted area in japanese docs.
Please check it.


![image](https://user-images.githubusercontent.com/2771212/99008065-c83aaa80-2588-11eb-8ff0-bbbef2dc6d4c.png)
